### PR TITLE
feat(sync): add one-time manual sync from website to Gitorial VSCode extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM node:alpine
 COPY . /dcs-frontend
 WORKDIR /dcs-frontend
 
-# Install Yarn if it's not installed
+# Install pnpm if it's not installed
 RUN if ! command -v pnpm &> /dev/null; then npm install --global pnpm; fi
 
 # Install dependencies
-RUN pnpm
+RUN pnpm install
 
 # Build the app
 RUN pnpm build

--- a/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorComponents.tsx
+++ b/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorComponents.tsx
@@ -19,12 +19,16 @@ export const EditorComponents = ({
   solution,
   editorContent,
   mdxContent,
+  gitorialUrl,
+  commitHash,
 }: {
   showHints: boolean;
   readOnly?: boolean;
   solution: TypeFile[];
   editorContent: TypeFile[];
   mdxContent?: React.ReactNode;
+  gitorialUrl?: string;
+  commitHash?: string;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -48,6 +52,8 @@ export const EditorComponents = ({
     editorContent,
     isOpen,
     handleFullscreenToggle,
+    gitorialUrl,
+    commitHash,
   };
 
   return (

--- a/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/EditorTabList.tsx
+++ b/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/EditorTabList.tsx
@@ -17,6 +17,8 @@ type EditorTabListProps = TabListProps & {
   toggleDiff: () => void;
   handleTabClick: () => void;
   isUserInteraction: React.MutableRefObject<boolean>;
+  gitorialUrl?: string;
+  commitHash?: string;
 };
 
 export const EditorTabList = ({
@@ -29,6 +31,8 @@ export const EditorTabList = ({
   toggleDiff,
   handleTabClick,
   isUserInteraction,
+  gitorialUrl,
+  commitHash,
   ...props
 }: EditorTabListProps) => (
   <TabList>
@@ -60,6 +64,8 @@ export const EditorTabList = ({
     </Flex>
     {showActions ? (
       <EditorTabListActions
+        gitorialUrl={gitorialUrl}
+        commitHash={commitHash}
         editorContent={editorContent}
         handleFullscreenToggle={handleFullscreenToggle}
         isOpen={isOpen}

--- a/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/EditorTabListActions.tsx
+++ b/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/EditorTabListActions.tsx
@@ -1,10 +1,11 @@
-import { Flex, Tooltip, IconButton } from "@chakra-ui/react";
+import { Flex, Tooltip, IconButton, useDisclosure } from "@chakra-ui/react";
 import { isEmpty } from "lodash";
-import React from "react";
-import { FiMaximize2, FiMinimize2 } from "react-icons/fi";
+import React, { useMemo } from "react";
+import { FiMaximize2, FiMinimize2, FiCloud, FiCloudOff } from "react-icons/fi";
 import { IoGitCompareOutline } from "react-icons/io5";
 
 import { TypeFile } from "@/lib/types";
+import IdeSelectionModal from "./IdeSelectionModal";
 
 const getFullscreenLabel = (isOpen: boolean) =>
   isOpen ? "Exit Fullscreen Code Editor" : "Enter Fullscreen Code Editor";
@@ -19,6 +20,8 @@ export const EditorTabListActions: React.FC<{
   showDiff: boolean;
   toggleDiff: () => void;
   isUserInteraction: React.MutableRefObject<boolean>;
+  gitorialUrl?: string;
+  commitHash?: string;
 }> = ({
   editorContent,
   isOpen,
@@ -26,44 +29,87 @@ export const EditorTabListActions: React.FC<{
   showDiff,
   toggleDiff,
   isUserInteraction,
-}) => (
-  <Flex
-    alignItems="center"
-    display={isEmpty(editorContent) ? "none" : "flex"}
-    px={2}
-  >
-    <Tooltip
-      hasArrow
-      label={showDiff ? "Hide Changes" : "Open Changes"}
-      maxW={32}
-      textAlign="center"
+  gitorialUrl,
+  commitHash,
+}) => {
+  const {
+    isOpen: isIdeModalOpen,
+    onOpen: onIdeModalOpen,
+    onClose: onIdeModalClose,
+  } = useDisclosure();
+
+  const creator = useMemo(() => {
+    if (!gitorialUrl) return "";
+    const url = new URL(gitorialUrl);
+    return url.pathname.split("/")[1];
+  }, [gitorialUrl]);
+
+  const repo = useMemo(() => {
+    if (!gitorialUrl) return "";
+    const url = new URL(gitorialUrl);
+    return url.pathname.split("/")[2];
+  }, [gitorialUrl]);
+
+  return (
+    <Flex
+      alignItems="center"
+      display={isEmpty(editorContent) ? "none" : "flex"}
+      px={2}
     >
-      <IconButton
-        aria-label={showDiff ? "Hide Changes" : "Open Changes"}
-        bg="none"
-        icon={<IoGitCompareOutline size={18} />}
-        onClick={() => {
-          isUserInteraction.current = showDiff;
-          toggleDiff();
-        }}
-        p={0}
-        size="sm"
-      />
-    </Tooltip>
-    <Tooltip
-      hasArrow
-      label={getFullscreenLabel(isOpen)}
-      maxW={32}
-      textAlign="center"
-    >
-      <IconButton
-        aria-label={getFullscreenLabel(isOpen)}
-        bg="none"
-        icon={getFullscreenIcon(isOpen)}
-        onClick={handleFullscreenToggle}
-        p={0}
-        size="sm"
-      />
-    </Tooltip>
-  </Flex>
-);
+      {gitorialUrl && commitHash && (
+        <Tooltip hasArrow label="Open in IDE" maxW={32} textAlign="center">
+          <IconButton
+            aria-label="Open in IDE"
+            bg="none"
+            icon={<FiCloud size={18} />}
+            onClick={onIdeModalOpen}
+            p={0}
+            size="sm"
+          />
+        </Tooltip>
+      )}
+      <Tooltip
+        hasArrow
+        label={showDiff ? "Hide Changes" : "Open Changes"}
+        maxW={32}
+        textAlign="center"
+      >
+        <IconButton
+          aria-label={showDiff ? "Hide Changes" : "Open Changes"}
+          bg="none"
+          icon={<IoGitCompareOutline size={18} />}
+          onClick={() => {
+            isUserInteraction.current = showDiff;
+            toggleDiff();
+          }}
+          p={0}
+          size="sm"
+        />
+      </Tooltip>
+      <Tooltip
+        hasArrow
+        label={getFullscreenLabel(isOpen)}
+        maxW={32}
+        textAlign="center"
+      >
+        <IconButton
+          aria-label={getFullscreenLabel(isOpen)}
+          bg="none"
+          icon={getFullscreenIcon(isOpen)}
+          onClick={handleFullscreenToggle}
+          p={0}
+          size="sm"
+        />
+      </Tooltip>
+      {gitorialUrl && commitHash && (
+        <IdeSelectionModal
+          isOpen={isIdeModalOpen}
+          onClose={onIdeModalClose}
+          creator={creator}
+          repo={repo}
+          commitHash={commitHash}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/IdeSelectionModal.tsx
+++ b/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/IdeSelectionModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  Radio,
+  RadioGroup,
+  Stack,
+  Text,
+  Box,
+  HStack,
+  Icon,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { SiVisualstudiocode } from "react-icons/si";
+import { VscCode } from "react-icons/vsc";
+import { FiCode } from "react-icons/fi";
+import { ButtonPrimary } from "@/components";
+import { createSyncUri } from "@/app/courses/helpers/gitorialCommands";
+
+interface IdeSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  creator: string;
+  repo: string;
+  commitHash: string;
+}
+
+const IdeSelectionModal = ({
+  isOpen,
+  onClose,
+  creator,
+  repo,
+  commitHash,
+}: IdeSelectionModalProps) => {
+  const [selectedIde, setSelectedIde] = useState("cursor");
+
+  const ides = [
+    {
+      id: "cursor",
+      name: "Cursor",
+      icon: FiCode,
+      description: "AI-powered code editor with advanced features",
+      protocol: "cursor",
+    },
+    {
+      id: "vscode",
+      name: "Visual Studio Code",
+      icon: SiVisualstudiocode,
+      description: "Popular open-source code editor by Microsoft",
+      protocol: "vscode",
+    },
+    {
+      id: "vscodium",
+      name: "VSCodium",
+      icon: VscCode,
+      description: "Open-source binaries of VS Code without telemetry",
+      protocol: "vscodium",
+    },
+  ];
+
+  const handleOpenInIde = () => {
+    const selectedIdeData = ides.find((ide) => ide.id === selectedIde);
+    if (selectedIdeData) {
+      const syncUri = createSyncUri(
+        selectedIdeData.protocol,
+        "github",
+        creator,
+        repo,
+        commitHash,
+      );
+      window.open(syncUri, "_blank");
+    }
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Choose Your IDE</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text mb={4}>Select your preferred IDE to open the code:</Text>
+          <RadioGroup onChange={setSelectedIde} value={selectedIde}>
+            <Stack spacing={4}>
+              {ides.map((ide) => (
+                <Box
+                  key={ide.id}
+                  p={4}
+                  borderWidth="1px"
+                  borderRadius="md"
+                  borderColor={
+                    selectedIde === ide.id ? "green.500" : "gray.400"
+                  }
+                  bg={selectedIde === ide.id ? "green.800" : "gray.600"}
+                  cursor="pointer"
+                  onClick={() => setSelectedIde(ide.id)}
+                >
+                  <Radio value={ide.id}>
+                    <HStack spacing={3} mt={1}>
+                      <Icon as={ide.icon} boxSize={5} />
+                      <Text fontWeight="bold">{ide.name}</Text>
+                    </HStack>
+                  </Radio>
+                  <Text ml={6} mt={2} fontSize="sm" color="gray.300">
+                    {ide.description}
+                  </Text>
+                </Box>
+              ))}
+            </Stack>
+          </RadioGroup>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <ButtonPrimary onClick={handleOpenInIde}>
+            Open in {ides.find((ide) => ide.id === selectedIde)?.name}
+          </ButtonPrimary>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default IdeSelectionModal;

--- a/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/index.tsx
+++ b/app/courses/[course]/(pages)/section/[section]/lesson/[lesson]/components/EditorTabs/index.tsx
@@ -12,6 +12,8 @@ export type EditorTabsProps = {
   showActions?: boolean;
   readOnly: boolean;
   isOpen: boolean;
+  gitorialUrl?: string;
+  commitHash?: string;
   handleFullscreenToggle: (e: React.MouseEvent) => void;
 };
 
@@ -20,6 +22,8 @@ export const EditorTabsComponent = ({
   readOnly,
   isOpen,
   showActions = true,
+  gitorialUrl,
+  commitHash,
   handleFullscreenToggle,
 }: EditorTabsProps) => {
   const {
@@ -45,6 +49,8 @@ export const EditorTabsComponent = ({
         isOpen={isOpen}
         showActions={showActions}
         showDiff={showDiff}
+        gitorialUrl={gitorialUrl}
+        commitHash={commitHash}
         {...editorProps}
       />
       <EditorTabPanels

--- a/app/courses/[course]/helpers/getMdxCourseDetails.ts
+++ b/app/courses/[course]/helpers/getMdxCourseDetails.ts
@@ -167,6 +167,7 @@ export const getMdxCourseDetails = async (slug: string) => {
         last_updated: lessonData.last_updated || null, // Add last_updated from lesson metadata
         hasFiles,
         fileType,
+        commit_hash: lessonData.commit_hash,
       });
     }
 
@@ -187,6 +188,7 @@ export const getMdxCourseDetails = async (slug: string) => {
   sections.sort((a, b) => a.order - b.order);
 
   // Create the course details object
+  //TODO: consistent naming camelCase
   const courseDetails = {
     title: data.title || slug,
     description: data.description || "",
@@ -198,6 +200,7 @@ export const getMdxCourseDetails = async (slug: string) => {
     format: "mdxCourse",
     slug: data.slug || slug,
     githubUrl: data.github_url || "",
+    isGitorial: data.is_gitorial || false,
     prerequisites: data.prerequisites || [],
     whatYoullLearn: data.what_youll_learn || [],
     estimated_time: data.estimated_time || null, // Add estimated time from metadata

--- a/app/courses/[course]/lesson/[sectionId]/[lessonId]/components/MdxLessonView.tsx
+++ b/app/courses/[course]/lesson/[sectionId]/[lessonId]/components/MdxLessonView.tsx
@@ -49,6 +49,9 @@ type LessonData = {
     next: { link: string; title: string };
     courseLink: string;
   };
+  githubUrl?: string;
+  commitHash?: string;
+  isGitorial?: boolean;
   courseSlug: string;
   currentSectionId: string;
   currentLessonId: string;
@@ -81,6 +84,9 @@ const MdxLessonView = ({ lessonData }: MdxLessonViewProps) => {
     currentSectionId,
     currentLessonId,
     sections,
+    githubUrl,
+    commitHash,
+    isGitorial,
   } = lessonData;
 
   // For mobile sidebar
@@ -128,6 +134,11 @@ const MdxLessonView = ({ lessonData }: MdxLessonViewProps) => {
   const editorFiles = sourceFiles || templateFiles || [];
   const isReadOnly = !!sourceFiles; // Read-only if we're showing source files
   const showHints = !!templateFiles && !!solutionFiles; // Show hints if we have template and solution files
+
+  const gitorialUrl = React.useMemo(
+    () => (isGitorial ? githubUrl : undefined),
+    [isGitorial, githubUrl],
+  );
 
   return (
     <Box
@@ -409,6 +420,8 @@ const MdxLessonView = ({ lessonData }: MdxLessonViewProps) => {
                   readOnly={isReadOnly}
                   showHints={showHints}
                   solution={solutionFiles || []}
+                  gitorialUrl={gitorialUrl}
+                  commitHash={commitHash}
                 />
               </Flex>
             </Box>

--- a/app/courses/[course]/lesson/[sectionId]/[lessonId]/page.tsx
+++ b/app/courses/[course]/lesson/[sectionId]/[lessonId]/page.tsx
@@ -170,6 +170,9 @@ const LessonPage = async ({ params }: LessonPageProps) => {
       currentSectionId: sectionId,
       currentLessonId: lessonId,
       sections: mdxCourse.sections,
+      githubUrl: mdxCourse.githubUrl,
+      isGitorial: mdxCourse.isGitorial,
+      commitHash: lesson.commit_hash,
     };
 
     console.log(

--- a/app/courses/helpers/getLocalCourses.ts
+++ b/app/courses/helpers/getLocalCourses.ts
@@ -48,6 +48,7 @@ export const getLocalCourses = async (): Promise<CourseOverview[]> => {
 
     // Skip if the MDX file doesn't exist
     if (!fs.existsSync(mdxFilePath)) {
+      console.warn(`MDX file does not exist for course: ${courseSlug}`);
       continue;
     }
 

--- a/app/courses/helpers/gitorialCommands.ts
+++ b/app/courses/helpers/gitorialCommands.ts
@@ -1,0 +1,21 @@
+/**
+ *
+ * @param ide - The IDE to use.
+ * @param platform - The platform where the gitorial is hosted.
+ * @param creator - The creator of the gitorial.
+ * @param repo - The repository of the gitorial.
+ * @param commitHash - The commit hash of the gitorial.
+ * @returns
+ *
+ * Example:
+ * "cursor://AndrzejSulkowski.gitorial/sync?platform=github&creator=shawntabrizi&repo=rust-state-machine&commitHash=b74e58d9b3165a2e18f11f0fead411a754386c75"
+ */
+export function createSyncUri(
+  ide: string,
+  platform: string,
+  creator: string,
+  repo: string,
+  commitHash: string,
+): string {
+  return `${ide}://AndrzejSulkowski.gitorial/sync?platform=${platform}&creator=${creator}&repo=${repo}&commitHash=${commitHash}`;
+}


### PR DESCRIPTION
# Pull Request

## Description

Manually synchronize the current tutorial from DotCodeSchool to your local Gitorial VS Code extension. Available only on courses marked `is_gitorial` with a valid `github_url`. Once the one-time sync completes, both the website and extension operate independently.


## Type of Change

<!-- Please check the relevant options -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Content addition (new article or course)
- [ ] Content update (changes to existing articles or courses)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issues

<!-- Please link any related issues here. Use the format: "Fixes #123" or "Relates to #123" -->

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [x] I have tested my changes (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes do not generate new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Screenshots

<img width="555" alt="image" src="https://github.com/user-attachments/assets/1938245d-cc08-4269-99e4-5311efcf786a" />

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/50a2ef52-6f8f-4208-96a8-e0ed9f45378a" />
